### PR TITLE
feat: add Internal Safety Collapse (ISC) to Agent Safety section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2003,6 +2003,12 @@ First, we conducted a keyword-based search targeting specific model types and th
 
 <summary><span id="ch7">Agent Safety</summary>
 
+##### Internal Safety Collapse
+
+- Internal Safety Collapse in Frontier Large Language Models.  
+  - Wu, Yutao, Liu, Xiao, Gao, Yifeng, Zheng, Xiang, Huang, Hanxun, Li, Yige, Wang, Cong, Li, Bo, Ma, Xingjun, **and** Jiang, Yu-Gang  
+  - *ICML*, 2026.
+
 ##### Indirect Prompt Injection Attacks
 
 - Not what you've signed up for: Compromising real-world llm-integrated applications with indirect prompt injection.  

--- a/README.md
+++ b/README.md
@@ -2007,7 +2007,7 @@ First, we conducted a keyword-based search targeting specific model types and th
 
 - Internal Safety Collapse in Frontier Large Language Models.  
   - Wu, Yutao, Liu, Xiao, Gao, Yifeng, Zheng, Xiang, Huang, Hanxun, Li, Yige, Wang, Cong, Li, Bo, Ma, Xingjun, **and** Jiang, Yu-Gang  
-  - *ICML*, 2026.
+  - *arXiv preprint arXiv:2603.23509*, 2026.
 
 ##### Indirect Prompt Injection Attacks
 


### PR DESCRIPTION
## Summary

Adds **Internal Safety Collapse (ISC)** as the first entry in the Agent Safety chapter.

ISC reveals that frontier LLMs generate harmful content as a **functional requirement of legitimate professional tasks** — no adversarial prompts or jailbreaks needed. The task structure itself is the exploit.

**Paper:** [Internal Safety Collapse in Frontier Large Language Models](https://arxiv.org/abs/2603.23509)  
**Benchmark:** [ISC-Bench](https://github.com/wuyoscar/ISC-Bench) — 80 templates, 9 domains, 51/100 top Arena models confirmed

## Entry added

New `##### Internal Safety Collapse` subsection at the top of Chapter 7 (Agent Safety):

```
- Internal Safety Collapse in Frontier Large Language Models.  
  - Wu, Yutao, Liu, Xiao, Gao, Yifeng, Zheng, Xiang, Huang, Hanxun, Li, Yige, Wang, Cong, Li, Bo, Ma, Xingjun, and Jiang, Yu-Gang  
  - arXiv preprint arXiv:2603.23509, 2026.
```